### PR TITLE
Add Semigroup.<> implementations

### DIFF
--- a/library/ByteString/StrictBuilder.hs
+++ b/library/ByteString/StrictBuilder.hs
@@ -28,6 +28,7 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as C
 import qualified Data.ByteString.Lazy as F
 import qualified Data.ByteString.Builder.Internal as G
+import qualified Data.Semigroup
 import qualified ByteString.StrictBuilder.UTF8 as E
 
 
@@ -50,7 +51,8 @@ instance Monoid Builder where
       population =
         foldMap (\(Builder _ x) -> x) builders
 
-instance Semigroup Builder
+instance Semigroup Builder where
+  (<>) = mappend
 
 instance IsString Builder where
   fromString =

--- a/library/ByteString/StrictBuilder/Population.hs
+++ b/library/ByteString/StrictBuilder/Population.hs
@@ -5,6 +5,7 @@ import ByteString.StrictBuilder.Prelude
 import qualified Data.ByteString.Internal as B
 import qualified Data.ByteString.Lazy.Internal as C
 import qualified Data.ByteString.Builder.Internal as G
+import qualified Data.Semigroup
 import qualified ByteString.StrictBuilder.Population.UncheckedShifting as D
 import qualified ByteString.StrictBuilder.UTF8 as E
 
@@ -20,7 +21,8 @@ instance Monoid Population where
   mappend (Population leftPtrUpdate) (Population rightPtrUpdate) =
     Population (leftPtrUpdate >=> rightPtrUpdate)
 
-instance Semigroup Population
+instance Semigroup Population where
+  (<>) = mappend
 
 
 {-|


### PR DESCRIPTION
To avoid crash on ghc-8.4/base-4.11/semigroups-0.18 where there is no longer the default implementation from Monoid.

Without this, I get a runtime failure of
```
library/ByteString/StrictBuilder/Population.hs:23:10-29: No instance nor default method for class operation <>
```