### PR TITLE
Fix: 8.2.2 build

### DIFF
--- a/library/ByteString/StrictBuilder/Prelude.hs
+++ b/library/ByteString/StrictBuilder/Prelude.hs
@@ -4,6 +4,6 @@ module ByteString.StrictBuilder.Prelude
 )
 where
 
-import BasePrelude as Exports
+import BasePrelude as Exports hiding ((<>))
 import Data.ByteString as Exports (ByteString)
-import Data.Semigroup as Exports hiding ((<>), Last(..), First(..))
+import Data.Semigroup as Exports hiding (Last(..), First(..))


### PR DESCRIPTION
Fixes
```
library/ByteString/StrictBuilder/Population.hs:24:3: error:
    ‘<>’ is not a (visible) method of class ‘Semigroup’
   |
24 |   (<>) = mappend

```
error when building with ghc-8.2.2