### PR TITLE
Speed up mconcat with foldl'

### DIFF
--- a/bytestring-strict-builder.cabal
+++ b/bytestring-strict-builder.cabal
@@ -100,5 +100,5 @@ benchmark benchmarks
     Haskell2010
   build-depends:
     bytestring-strict-builder,
-    criterion >= 1.1 && < 1.5,
+    criterion >= 1.1 && < 1.6,
     rerebase == 1.*

--- a/library/ByteString/StrictBuilder.hs
+++ b/library/ByteString/StrictBuilder.hs
@@ -46,7 +46,7 @@ instance Monoid Builder where
     Builder size population
     where
       size =
-        getSum (foldMap (\(Builder x _) -> Sum x) builders)
+        foldl' (\acc (Builder x _) -> acc + x) 0 builders
       population =
         foldMap (\(Builder _ x) -> x) builders
 


### PR DESCRIPTION
By using `foldl'` to determine the size, we reduce the boxing overhead during the size computation,
resulting in a ~41% speedup for the concat benchmark.