### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/bytestring-strict-builder.cabal
+++ b/bytestring-strict-builder.cabal
@@ -55,10 +55,11 @@ library
     ByteString.StrictBuilder.Population.UncheckedShifting
     ByteString.StrictBuilder.UTF8
   build-depends:
-    semigroups >= 0.18 && < 0.20,
     bytestring >= 0.10.2 && < 0.11,
     base-prelude >= 1.2 && < 2,
     base >= 4.6 && < 5
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.18 && < 0.20
 
 test-suite tests
   type:


### PR DESCRIPTION
They are not needed on newer GHC.