### PR TITLE
Replace composition with eta-expansion for GHC 9.

### DIFF
--- a/library/ByteString/StrictBuilder/UTF8.hs
+++ b/library/ByteString/StrictBuilder/UTF8.hs
@@ -19,8 +19,8 @@ type UTF8Char =
 
 {-# INLINE char #-}
 char :: Char -> UTF8Char
-char =
-  unicodeCodePoint . ord
+char c =
+  unicodeCodePoint $ ord c
 
 {-# INLINE unicodeCodePoint #-}
 unicodeCodePoint :: Int -> UTF8Char


### PR DESCRIPTION
I'm still trying to build packages under GHC 9.  The problem here is the new simplified subsumption (https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst), which causes the `forall` in `UTF8Char` to not be floated out, so that an argument of `(.)` is polymorphic, which the compiler rejects as impredicative.  This can be solved by eta-expanding.

An alternative would be to turn on the shaky extension `-XImpredicativeTypes`.  This would probably be a stop-gap till quick-look impredicativity is implemented (hopefully GHC 9.2), at which point the original definition would presumably be accepted again.  I don't know if it's worth this trouble to avoid one eta-expansion.

I had to do the exact same thing in `text-builder`.