### PR TITLE
Update for 9.2 (base 4.16)

### DIFF
--- a/library/ByteString/StrictBuilder/Population/UncheckedShifting.hs
+++ b/library/ByteString/StrictBuilder/Population/UncheckedShifting.hs
@@ -62,8 +62,13 @@ shiftr_w w s = fromIntegral $ (`shiftr_w64` s) $ fromIntegral w
 #endif
 
 #if !defined(__HADDOCK__)
+#if MIN_VERSION_base(4,16,0)
+shiftr_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftRLWord16#`   i)
+shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRLWord32#`   i)
+#else
 shiftr_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftRL#`   i)
 shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRL#`   i)
+#endif
 
 #if WORD_SIZE_IN_BITS < 64
 shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL64#` i)


### PR DESCRIPTION
Just the title.  It builds:

```
tommd@ovdak tmp/bytestring-strict-builder% cabal build
Up to date
tommd@ovdak tmp/bytestring-strict-builder% ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.2.1
tommd@ovdak tmp/bytestring-strict-builder% git rev-parse HEAD
a15bfe734e78ff9fa10bd608afd8d942d165b200
```