### PR TITLE
experiment: Avoid copy when building from a single strict bytestring

### DIFF
--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -6,7 +6,7 @@ import ByteString.StrictBuilder
 
 
 main =
-  defaultMain [leftAppends, rightAppends, concat]
+  defaultMain [leftAppends, rightAppends, concat, copy]
 
 leftAppends :: Benchmark
 leftAppends =
@@ -34,3 +34,11 @@ concat =
   where
     action bytesList =
       builderBytes (mconcat bytesList)
+
+copy :: Benchmark
+copy =
+  bench "copy" $ whnf action $! bytes dat
+  where
+    dat = builderBytes $ mconcat $ replicate 1000000 $ bytes "abc"
+    action bs =
+      builderBytes bs

--- a/library/ByteString/StrictBuilder.hs
+++ b/library/ByteString/StrictBuilder.hs
@@ -77,7 +77,9 @@ Efficiently constructs a strict bytestring.
 {-# INLINE builderBytes #-}
 builderBytes :: Builder -> ByteString
 builderBytes (Builder size population) =
-  C.unsafeCreate size $ \ptr -> A.populationPtrUpdate population ptr $> ()
+  case population of
+    A.Population upd -> C.unsafeCreate size $ \ptr -> upd ptr $> ()
+    A.Bytes bs -> bs
 
 {-|
 Converts into the standard lazy bytestring builder.


### PR DESCRIPTION
This is a rather naive attempt at avoiding the copy when building from a single strict bytestring, as discussed over at https://github.com/nikita-volkov/hasql/pull/146.

Includes a copying benchmark, and it does massively improve that one, but the negative effect on the other benchmarks makes me doubt this is a good change :/

before:
```
benchmarking leftAppends
time                 19.79 μs   (19.66 μs .. 20.02 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 19.83 μs   (19.70 μs .. 20.10 μs)
std dev              568.7 ns   (292.9 ns .. 928.4 ns)
variance introduced by outliers: 31% (moderately inflated)

benchmarking rightAppends
time                 20.68 μs   (20.44 μs .. 21.00 μs)
                     0.997 R²   (0.994 R² .. 1.000 R²)
mean                 20.94 μs   (20.59 μs .. 22.16 μs)
std dev              1.812 μs   (591.2 ns .. 3.547 μs)
variance introduced by outliers: 81% (severely inflated)

benchmarking concat
time                 170.3 μs   (163.8 μs .. 181.3 μs)
                     0.983 R²   (0.962 R² .. 0.999 R²)
mean                 166.4 μs   (164.0 μs .. 172.5 μs)
std dev              12.74 μs   (4.563 μs .. 25.17 μs)
variance introduced by outliers: 70% (severely inflated)

benchmarking copy
time                 423.5 μs   (413.7 μs .. 442.3 μs)
                     0.993 R²   (0.984 R² .. 1.000 R²)
mean                 417.9 μs   (414.3 μs .. 427.5 μs)
std dev              18.41 μs   (5.076 μs .. 36.19 μs)
variance introduced by outliers: 38% (moderately inflated)
```

after:
```
benchmarking leftAppends
time                 19.68 μs   (19.60 μs .. 19.84 μs)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 20.36 μs   (19.87 μs .. 21.54 μs)
std dev              2.532 μs   (870.7 ns .. 4.173 μs)
variance introduced by outliers: 90% (severely inflated)

benchmarking rightAppends
time                 25.28 μs   (25.23 μs .. 25.33 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 25.29 μs   (25.25 μs .. 25.36 μs)
std dev              168.5 ns   (119.7 ns .. 244.2 ns)

benchmarking concat
time                 343.0 μs   (341.1 μs .. 345.0 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 350.1 μs   (344.2 μs .. 379.0 μs)
std dev              37.86 μs   (1.834 μs .. 86.90 μs)
variance introduced by outliers: 81% (severely inflated)

benchmarking copy
time                 4.865 ns   (4.809 ns .. 4.918 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 4.842 ns   (4.778 ns .. 4.899 ns)
std dev              211.5 ps   (172.3 ps .. 258.0 ps)
variance introduced by outliers: 69% (severely inflated)
```